### PR TITLE
Add support for different encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple RSS and ATOM feed reader for the Go programming language.
 
+## Dependencies
+
+- golang.org/x/text/encoding/charmap
+
 ## Usage
 
 Send an io.Reader to rss.Get() and it'll do the rest.
@@ -9,3 +13,45 @@ Send an io.Reader to rss.Get() and it'll do the rest.
 ### Date/Time Parsing
 
 RSS Go will attempt to parse the date/time values it discovers.
+
+### Encoding
+
+RSS Go currently supports the following encoding:
+- CodePage437
+- CodePage850
+- CodePage852
+- CodePage855
+- CodePage858
+- CodePage862
+- CodePage866
+- ISO8859-1
+- ISO8859-2
+- ISO8859-3
+- ISO8859-4
+- ISO8859-5
+- ISO8859-6
+- ISO8859-6E
+- ISO8859-6I
+- ISO8859-7
+- ISO8859-8
+- ISO8859-8E
+- ISO8859-8I
+- ISO8859-10
+- ISO8859-13
+- ISO8859-14
+- ISO8859-15
+- ISO8859-16
+- KOI8R
+- KOI8U
+- Macintosh
+- MacintoshCyrillic
+- Windows874
+- Windows1250
+- Windows1251
+- Windows1252
+- Windows1253
+- Windows1254
+- Windows1255
+- Windows1256
+- Windows1257
+- Windows1258

--- a/rss.go
+++ b/rss.go
@@ -3,11 +3,16 @@ package rss
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"strings"
 	"time"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
 )
 
+// Defines an RSS/Atom feed
 type Feed struct {
 	Title    string
 	Subtitle string
@@ -15,6 +20,7 @@ type Feed struct {
 	Items    []*Item
 }
 
+// Defines a feed item
 type Item struct {
 	Id          string
 	Title       string
@@ -50,20 +56,80 @@ const (
 	levelPost = 2
 )
 
+var charsetMap = map[string]encoding.Encoding{
+	"codepage437":       charmap.CodePage437,
+	"codepage850":       charmap.CodePage850,
+	"CodePage852":       charmap.CodePage852,
+	"CodePage855":       charmap.CodePage855,
+	"CodePage858":       charmap.CodePage858,
+	"CodePage862":       charmap.CodePage862,
+	"CodePage866":       charmap.CodePage866,
+	"iso88591":          charmap.ISO8859_1,
+	"iso88592":          charmap.ISO8859_2,
+	"iso88593":          charmap.ISO8859_3,
+	"iso88594":          charmap.ISO8859_4,
+	"iso88595":          charmap.ISO8859_5,
+	"iso88596":          charmap.ISO8859_6,
+	"iso88596E":         charmap.ISO8859_6E,
+	"iso88596I":         charmap.ISO8859_6I,
+	"iso88597":          charmap.ISO8859_7,
+	"iso88598":          charmap.ISO8859_8,
+	"iso88598E":         charmap.ISO8859_8E,
+	"iso88598I":         charmap.ISO8859_8I,
+	"iso885910":         charmap.ISO8859_10,
+	"iso885913":         charmap.ISO8859_13,
+	"iso885914":         charmap.ISO8859_14,
+	"iso885915":         charmap.ISO8859_15,
+	"iso885916":         charmap.ISO8859_16,
+	"koi8r":             charmap.KOI8R,
+	"koi8u":             charmap.KOI8U,
+	"macintosh":         charmap.Macintosh,
+	"macintoshcyrillic": charmap.MacintoshCyrillic,
+	"windows874":        charmap.Windows874,
+	"windows1250":       charmap.Windows1250,
+	"windows1251":       charmap.Windows1251,
+	"windows1252":       charmap.Windows1252,
+	"windows1253":       charmap.Windows1253,
+	"windows1254":       charmap.Windows1254,
+	"windows1255":       charmap.Windows1255,
+	"windows1256":       charmap.Windows1256,
+	"windows1257":       charmap.Windows1257,
+	"windows1258":       charmap.Windows1258,
+}
+
+// createCharsetReader Creates a new io.reader for a certain charset
+func createCharsetReader(charset string, input io.Reader) (io.Reader, error) {
+	key := strings.Replace(strings.Trim(strings.ToLower(charset), " "), "-", "", -1)
+
+	if enc, exists := charsetMap[key]; exists {
+		return enc.NewDecoder().Reader(input), nil
+	}
+
+	return nil, fmt.Errorf("Unknown charset: %s", charset)
+}
+
+// Get parses a RSS/Atom feed
 func Get(r io.Reader) (*Feed, error) {
 	var tag string
 	var atom bool
 	var level int
+
 	feed := &Feed{}
 	item := &Item{}
+
 	d := xml.NewDecoder(r)
+	d.CharsetReader = createCharsetReader
+	d.Strict = false
+
 	for {
 		token, err := d.Token()
+
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			return nil, err
 		}
+
 		switch t := token.(type) {
 		case xml.StartElement:
 			tag = strings.ToLower(t.Name.Local)
@@ -149,5 +215,6 @@ func Get(r io.Reader) (*Feed, error) {
 			}
 		}
 	}
+
 	return feed, nil
 }


### PR DESCRIPTION
Currently only UTF-8 is supported while parsing an RSS of Atom feed. With this pull request the following encodings will also be supported:
- CodePage437
- CodePage850
- CodePage852
- CodePage855
- CodePage858
- CodePage862
- CodePage866
- ISO8859-1
- ISO8859-2
- ISO8859-3
- ISO8859-4
- ISO8859-5
- ISO8859-6
- ISO8859-6E
- ISO8859-6I
- ISO8859-7
- ISO8859-8
- ISO8859-8E
- ISO8859-8I
- ISO8859-10
- ISO8859-13
- ISO8859-14
- ISO8859-15
- ISO8859-16
- KOI8R
- KOI8U
- Macintosh
- MacintoshCyrillic
- Windows874
- Windows1250
- Windows1251
- Windows1252
- Windows1253
- Windows1254
- Windows1255
- Windows1256
- Windows1257
- Windows1258
